### PR TITLE
fix #3: add a way to switch to primary clipboard on unix systems

### DIFF
--- a/clipboard/clipboard.go
+++ b/clipboard/clipboard.go
@@ -5,7 +5,17 @@
 package clipboard
 
 // clipboard is an unexported type that implements the Clipboard interface.
-type clipboard struct{}
+type clipboard struct {
+	Primary bool
+}
+
+// internal clipboard target flag
+var usePrimary bool
+
+// exported flag container
+type ClipboardOptions struct {
+	Primary bool
+}
 
 // Clipboard is the interface that wraps the basic clipboard operations.
 type Clipboard interface {
@@ -20,8 +30,14 @@ type Clipboard interface {
 
 // New creates and returns a new Clipboard instance that can be used
 // to interact with the system clipboard.
-func New() Clipboard {
-	return &clipboard{}
+func New(opts ...ClipboardOptions) Clipboard {
+	cb := &clipboard{}
+
+	if len(opts) == 1 {
+		usePrimary = opts[0].Primary
+	}
+
+	return cb
 }
 
 // CopyText implements the Clipboard interface's CopyText method.

--- a/clipboard/clipboard_unix.go
+++ b/clipboard/clipboard_unix.go
@@ -25,7 +25,7 @@ var newCmd = func(cmdName string, cmdArgs ...string) command.Command {
 // to execute the copy operation. An error is returned if the tool cannot be initialized or
 // if the TextInput method fails.
 func copyText(s string) error {
-	ct, err := clipboardtool.New()
+	ct, err := clipboardtool.New(usePrimary)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func copyText(s string) error {
 // It uses the clipboardtool package to determine the appropriate tool and command package
 // to execute the paste operation. It returns the pasted text and any error encountered.
 func pasteText() (string, error) {
-	ct, err := clipboardtool.New()
+	ct, err := clipboardtool.New(usePrimary)
 	if err != nil {
 		return "", err
 	}

--- a/clipboard/clipboardtool/clipboardtool.go
+++ b/clipboard/clipboardtool/clipboardtool.go
@@ -27,6 +27,6 @@ type clipboardTool struct {
 // New initializes and returns a new instance of clipboardTool.
 // It determines the appropriate tools to use based on the current system environment
 // and returns an error if no suitable tools are found.
-func New() (*clipboardTool, error) {
-	return newClipboardTool()
+func New(primary bool) (*clipboardTool, error) {
+	return newClipboardTool(primary)
 }

--- a/clipboard/clipboardtool/clipboardtool_darwin.go
+++ b/clipboard/clipboardtool/clipboardtool_darwin.go
@@ -37,7 +37,7 @@ var (
 
 // newClipboardTool initializes a new clipboardTool instance by
 // checking the availability of clipboard utilities.
-func newClipboardTool() (*clipboardTool, error) {
+func newClipboardTool(primary bool) (*clipboardTool, error) {
 	if isAvailable := isToolAvailable(copyTool.Name); !isAvailable {
 		return nil, errNoCopyUtilitiesFound
 	}

--- a/clipboard/clipboardtool/clipboardtool_darwin_test.go
+++ b/clipboard/clipboardtool/clipboardtool_darwin_test.go
@@ -65,7 +65,7 @@ func Test_newClipboardTool(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			lookPath = tc.lookPathMock
-			ct, err := newClipboardTool()
+			ct, err := newClipboardTool(false)
 			if err != nil {
 				if tc.expectedError == nil {
 					t.Fatalf("expected no error, got %v", err)

--- a/clipboard/clipboardtool/clipboardtool_unix _test.go
+++ b/clipboard/clipboardtool/clipboardtool_unix _test.go
@@ -104,7 +104,7 @@ func Test_newClipboardTool(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			lookPath = tc.lookPathMock
-			ct, err := newClipboardTool()
+			ct, err := newClipboardTool(false)
 			if err != nil {
 				if tc.expectedError == nil {
 					t.Fatalf("expected no error, got %v", err)

--- a/clipboard/clipboardtool/clipboardtool_unix.go
+++ b/clipboard/clipboardtool/clipboardtool_unix.go
@@ -64,6 +64,44 @@ var (
 			Name: termuxClipboardGet,
 		},
 	}
+
+	// same with primary selection
+	copyToolsPrimary = []*CopyTool{
+		{
+			Name:    xsel,
+			CmdArgs: []string{"--input", "--primary"},
+		},
+		{
+			Name:    xclip,
+			CmdArgs: []string{"-in", "-selection", "primary"},
+		},
+		{
+			Name:    wlcopy,
+			CmdArgs: []string{"--primary"},
+		},
+		{
+			Name: termuxClipboardSet,
+		},
+	}
+
+	pasteToolsPrimary = []*PasteTool{
+		{
+			Name:    xsel,
+			CmdArgs: []string{"--output", "--primary"},
+		},
+		{
+			Name:    xclip,
+			CmdArgs: []string{"-out", "-selection", "primary"},
+		},
+		{
+			Name:    wlpaste,
+			CmdArgs: []string{"--no-newline", "--primary"},
+		},
+		{
+			Name: termuxClipboardGet,
+		},
+	}
+
 	// lookPath is a variable holding the exec.LookPath function,
 	// used to check for the presence of a command in the system's PATH.
 	lookPath = exec.LookPath
@@ -73,9 +111,16 @@ var (
 
 // newClipboardTool selects the first available pair of
 // copy and paste tools from the predefined list.
-func newClipboardTool() (*clipboardTool, error) {
+func newClipboardTool(primary bool) (*clipboardTool, error) {
 	for i, ct := range copyTools {
-		pt := pasteTools[i]
+		var pt *PasteTool
+		if primary {
+			pt = pasteToolsPrimary[i]
+			ct = copyToolsPrimary[i]
+		} else {
+			pt = pasteTools[i]
+		}
+
 		if available := toolsAreAvailable(ct.Name, pt.Name); available {
 			return &clipboardTool{
 				CopyTool:  ct,

--- a/clipboard/clipboardtool/clipboardtool_windows.go
+++ b/clipboard/clipboardtool/clipboardtool_windows.go
@@ -39,7 +39,7 @@ var (
 
 // newClipboardTool checks the availability of clipboard utilities
 // and initializes a new clipboardTool.
-func newClipboardTool() (*clipboardTool, error) {
+func newClipboardTool(primary bool) (*clipboardTool, error) {
 	if isAvailable := toolIsAvailable(copyTool.Name); !isAvailable {
 		return nil, errNoCopyUtilitiesFound
 	}

--- a/clipboard/clipboardtool/clipboardtool_windows_test.go
+++ b/clipboard/clipboardtool/clipboardtool_windows_test.go
@@ -59,7 +59,7 @@ func Test_newClipboardTool(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			lookPath = tc.lookPathMock
-			ct, err := newClipboardTool()
+			ct, err := newClipboardTool(false)
 			if err != nil {
 				if tc.expectedError == nil {
 					t.Fatalf("expected no error, got %v", err)

--- a/examples/copy/copy.go
+++ b/examples/copy/copy.go
@@ -14,6 +14,11 @@ import (
 func main() {
 	text := "some text"
 	c := clipboard.New()
+
+	if len(os.Args) > 0 {
+		c = clipboard.New(clipboard.ClipboardOptions{Primary: true})
+	}
+
 	if err := c.CopyText(text); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/examples/paste/paste.go
+++ b/examples/paste/paste.go
@@ -13,7 +13,13 @@ import (
 
 func main() {
 	c := clipboard.New()
+
+	if len(os.Args) > 0 {
+		c = clipboard.New(clipboard.ClipboardOptions{Primary: true})
+	}
+
 	text, err := c.PasteText()
+
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
An example usage can be found in examples.