### PR TITLE
Fix build, docs & add test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: build-and-test
+on: [push, pull_request]
+jobs:
+  build:
+    strategy:
+      matrix:
+        version: ['1.22', '1.23']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    name: Build
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '${{ matrix.version }}'
+      id: go
+
+    - name: checkout
+      uses: actions/checkout@v4
+
+    - name: build
+      run: go build
+
+    - name: test
+      run: make test
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.22
+      - uses: actions/checkout@v4
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It offers abilities for copying and pasting plain text.
 ## installation
 
 ```
-go get github.com/tiagomelo/go-clipboard
+go get github.com/tiagomelo/go-clipboard/clipboard
 ```
 
 ## documentation

--- a/clipboard/clipboard_darwin.go
+++ b/clipboard/clipboard_darwin.go
@@ -25,7 +25,7 @@ var newCmd = func(cmdName string, cmdArgs ...string) command.Command {
 // to execute the copy operation. An error is returned if the tool cannot be initialized or
 // if the TextInput method fails.
 func copyText(s string) error {
-	ct, err := clipboardtool.New()
+	ct, err := clipboardtool.New(usePrimary)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func copyText(s string) error {
 // It uses the clipboardtool package to determine the appropriate tool and command package
 // to execute the paste operation. It returns the pasted text and any error encountered.
 func pasteText() (string, error) {
-	ct, err := clipboardtool.New()
+	ct, err := clipboardtool.New(usePrimary)
 	if err != nil {
 		return "", err
 	}

--- a/clipboard/clipboard_windows.go
+++ b/clipboard/clipboard_windows.go
@@ -25,7 +25,7 @@ var newCmd = func(cmdName string, cmdArgs ...string) command.Command {
 // to execute the copy operation. An error is returned if the tool cannot be initialized or
 // if the TextInput method fails.
 func copyText(s string) error {
-	ct, err := clipboardtool.New()
+	ct, err := clipboardtool.New(usePrimary)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func copyText(s string) error {
 // It uses the clipboardtool package to determine the appropriate tool and command package
 // to execute the paste operation. It returns the pasted text and any error encountered.
 func pasteText() (string, error) {
-	ct, err := clipboardtool.New()
+	ct, err := clipboardtool.New(usePrimary)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- Fix #5: to be able to use the module one needs to go get the sub dir `clipboard`
- Fix #6: fix build on darwin and windows
- Add ci pipeline so that these kind of errors come up earlier (e.g. before merging)